### PR TITLE
Product URLs are now sent to the front-end for typeahead. #6639

### DIFF
--- a/product.py
+++ b/product.py
@@ -205,6 +205,9 @@ class Product:
     def elasticsearch_auto_complete(cls, phrase):
         """
         Handler for auto-completion via elastic-search.
+        The product's URL is generated here as request context is available
+        here. This is sent to the front-end for typeaheadJS to compile into
+        its suggestions template.
         """
         config = Pool().get('elasticsearch.configuration')(1)
 
@@ -218,7 +221,14 @@ class Product:
             doc_types=[config.make_type_name('product.product')],
             size=5
         ):
-            results.append({"value": product.name})
+            results.append(
+                {
+                    "display_name": product.name,
+                    "url": cls(product.id).get_absolute_url(
+                        _external=True
+                    ),
+                }
+            )
 
         return results
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -501,13 +501,26 @@ class TestProduct(NereidTestCase):
             self.update_treenode_mapping()
             self.setup_defaults()
             self.create_products()
+            app = self.get_app()
+
             self.IndexBacklog.update_index()
             time.sleep(5)
 
-            results = self.NereidWebsite.auto_complete('product')
+            with app.test_request_context('/'):
+                results = self.NereidWebsite.auto_complete('product')
 
-            self.assertIn({'value': self.template1.name}, results)
-            self.assertIn({'value': self.template2.name}, results)
+                self.assertIn({
+                    'display_name': self.template1.name,
+                    'url': self.template1.products[0].get_absolute_url(
+                        _external=True
+                    ),
+                }, results)
+                self.assertIn({
+                    'display_name': self.template2.name,
+                    'url': self.template2.products[0].get_absolute_url(
+                        _external=True
+                    ),
+                }, results)
 
             self.clear_server()
 


### PR DESCRIPTION
In addition to product names, product URLs are sent to the front-end for typeaheadJS to compile into its suggestions template.