### PR TITLE
Modified product mapping to fix terms facet tokenization issue. #6543

### DIFF
--- a/product.xml
+++ b/product.xml
@@ -17,6 +17,18 @@
             <field name="model" search="[('model', '=', 'product.product')]"/>
             <field name="mapping">
               {
+                  "dynamic_templates": [
+                      {
+                          "string_template": {
+                              "path_match": "attributes.*",
+                              "match_mapping_type": "string",
+                              "mapping": {
+                                  "type": "string",
+                                  "index": "not_analyzed"
+                              }
+                          }
+                      }
+                  ],
                   "properties": {
                       "code": {
                           "type": "string",

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -905,8 +905,8 @@ class TestProduct(NereidTestCase):
                 self.assertItemsEqual(
                     facets['size']['terms'],
                     [
-                        {'count': 1, 'term': 'xl'},
-                        {'count': 1, 'term': 'l'},
+                        {'count': 1, 'term': 'XL'},
+                        {'count': 1, 'term': 'L'},
                     ]
                 )
 
@@ -930,8 +930,8 @@ class TestProduct(NereidTestCase):
                 self.assertItemsEqual(
                     facets['size']['terms'],
                     [
-                        {'count': 1, 'term': 'l'},
-                        {'count': 0, 'term': 'xl'},
+                        {'count': 1, 'term': 'L'},
+                        {'count': 0, 'term': 'XL'},
                     ]
                 )
 


### PR DESCRIPTION
* Earlier, when filterable attributes were used for term faceting, the terms would get tokenized, which was undesirable.
* The solution was to add a `dynamic_templates` section in the mapping which would apply to each sub-field inside `attributes` field.
* This section allows us to set each sub-field's `index` as `not_analyzed`.

Ref: [Stackoverflow Link](http://stackoverflow.com/questions/27937630/setting-index-property-for-all-sub-fields-of-a-field/27938289).